### PR TITLE
Vita: Fix linking and add libnet initialization code

### DIFF
--- a/Makefile.vita
+++ b/Makefile.vita
@@ -3,12 +3,12 @@ COMMON_OBJS = SDLnet.o \
 	SDLnetselect.o \
 	SDLnetTCP.o \
 	SDLnetUDP.o \
-	showinterfaces.o
+	SDLnetvita.o
 
 PREFIX  = arm-vita-eabi
 CC      = $(PREFIX)-gcc
 AR      = $(PREFIX)-ar
-CFLAGS  = -Wl,-q -Wall -O3 -Iinclude -I$(VITASDK)/arm-vita-eabi/include/SDL2
+CFLAGS  = -Wl,-q -Wall -O3 -Iinclude -I$(VITASDK)/arm-vita-eabi/include/SDL2 -DTCP_NODELAY
 ASFLAGS = $(CFLAGS)
 
 LIBS    += -lSDL2

--- a/Makefile.vita
+++ b/Makefile.vita
@@ -8,7 +8,7 @@ COMMON_OBJS = SDLnet.o \
 PREFIX  = arm-vita-eabi
 CC      = $(PREFIX)-gcc
 AR      = $(PREFIX)-ar
-CFLAGS  = -Wl,-q -Wall -O3 -Iinclude -I$(VITASDK)/arm-vita-eabi/include/SDL2 -DTCP_NODELAY
+CFLAGS  = -Wl,-q -Wall -O3 -Iinclude -I$(VITASDK)/arm-vita-eabi/include/SDL2
 ASFLAGS = $(CFLAGS)
 
 LIBS    += -lSDL2

--- a/SDLnet.c
+++ b/SDLnet.c
@@ -109,7 +109,6 @@ int  SDLNet_Init(void)
             return(-1);
         }
 #elif defined(__vita__)
-        extern int SDLNet_Vita_InitNet(void);
         int ret = SDLNet_Vita_InitNet();
         if (ret) return(-1);
 #else
@@ -143,7 +142,6 @@ void SDLNet_Quit(void)
 #elif defined(__OS2__) && !defined(__EMX__)
         /* -- nothing */
 #elif defined(__vita__)
-        extern void SDLNet_Vita_QuitNet(void);
         SDLNet_Vita_QuitNet();
 #else
         /* Restore the SIGPIPE handler */

--- a/SDLnet.c
+++ b/SDLnet.c
@@ -108,6 +108,10 @@ int  SDLNet_Init(void)
             SDLNet_SetError("Couldn't initialize IBM OS/2 sockets");
             return(-1);
         }
+#elif defined(__vita__)
+        extern int SDLNet_Vita_InitNet(void);
+        int ret = SDLNet_Vita_InitNet();
+        if (ret) return(-1);
 #else
         /* SIGPIPE is generated when a remote socket is closed */
         void (*handler)(int);
@@ -138,6 +142,9 @@ void SDLNet_Quit(void)
         }
 #elif defined(__OS2__) && !defined(__EMX__)
         /* -- nothing */
+#elif defined(__vita__)
+        extern void SDLNet_Vita_QuitNet(void);
+        SDLNet_Vita_QuitNet();
 #else
         /* Restore the SIGPIPE handler */
         void (*handler)(int);

--- a/SDLnetsys.h
+++ b/SDLnetsys.h
@@ -58,9 +58,6 @@ typedef int socklen_t;
 #include <sys/ioctl.h>
 #endif
 #include <sys/time.h>
-#ifdef __vita__
-#include <sys/select.h>
-#endif
 #include <unistd.h>
 #include <fcntl.h>
 #include <netinet/in.h>
@@ -108,31 +105,5 @@ void SDLNet_SetLastError(int err);
 #endif
 
 #ifdef __vita__
-// These are all defined in SDLnetvita.c
-
-int SDLNet_Vita_InitNet(void);
-void SDLNet_Vita_QuitNet(void);
-
-// These are missing from our newlib, so replacements are provided in
-// SDLnetvita.c.
-
-char *_vita_inet_ntoa(struct in_addr in);
-in_addr_t _vita_inet_addr(const char *cp);
-struct hostent *_vita_gethostbyaddr(const void *addr, socklen_t len, int type);
-
-#undef inet_ntoa
-#undef inet_addr
-#undef gethostbyaddr
-#define inet_ntoa _vita_inet_ntoa
-#define inet_addr _vita_inet_addr
-#define gethostbyaddr _vita_gethostbyaddr
-
-// SDL2_net looks for these and uses them exactly as rand() and srand()
-// for some reason, and we don't have them in libc.
-
-#undef random
-#undef srandom
-#define random rand
-#define srandom srand
-
+#include "SDLnetvita.h"
 #endif

--- a/SDLnetsys.h
+++ b/SDLnetsys.h
@@ -58,6 +58,9 @@ typedef int socklen_t;
 #include <sys/ioctl.h>
 #endif
 #include <sys/time.h>
+#ifdef __vita__
+#include <sys/select.h>
+#endif
 #include <unistd.h>
 #include <fcntl.h>
 #include <netinet/in.h>
@@ -104,3 +107,32 @@ int SDLNet_GetLastError(void);
 void SDLNet_SetLastError(int err);
 #endif
 
+#ifdef __vita__
+// These are all defined in SDLnetvita.c
+
+int SDLNet_Vita_InitNet(void);
+void SDLNet_Vita_QuitNet(void);
+
+// These are missing from our newlib, so replacements are provided in
+// SDLnetvita.c.
+
+char *_vita_inet_ntoa(struct in_addr in);
+in_addr_t _vita_inet_addr(const char *cp);
+struct hostent *_vita_gethostbyaddr(const void *addr, socklen_t len, int type);
+
+#undef inet_ntoa
+#undef inet_addr
+#undef gethostbyaddr
+#define inet_ntoa _vita_inet_ntoa
+#define inet_addr _vita_inet_addr
+#define gethostbyaddr _vita_gethostbyaddr
+
+// SDL2_net looks for these and uses them exactly as rand() and srand()
+// for some reason, and we don't have them in libc.
+
+#undef random
+#undef srandom
+#define random rand
+#define srandom srand
+
+#endif

--- a/SDLnetvita.c
+++ b/SDLnetvita.c
@@ -1,0 +1,158 @@
+/*
+  SDL_net:  An example cross-platform network library for use with SDL
+  Copyright (C) 1997-2017 Sam Lantinga <slouken@libsdl.org>
+  Copyright (C) 2012 Simeon Maxein <smaxein@googlemail.com>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+/* $Id$ */
+
+#ifdef __vita__
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+
+#include <vitasdk.h>
+
+#define NET_INIT_SIZE (1 * 1024 * 1024)
+#ifndef SCE_NET_CTL_ERROR_NOT_TERMINATED
+#define SCE_NET_CTL_ERROR_NOT_TERMINATED 0x80412102
+#endif
+
+extern void /*SDLCALL*/ SDLNet_SetError(const char *fmt, ...);
+
+// Vita-related initialization stuff.
+
+static void *net_memory = NULL;
+
+// Call this in SDLNet_Init() before anything else.
+
+int SDLNet_Vita_InitNet(void)
+{
+    SceNetInitParam initparam;
+    int ret;
+
+    ret = sceSysmoduleLoadModule(SCE_SYSMODULE_NET);
+    if (ret) {
+        SDLNet_SetError("Could not load SCE_SYSMODULE_NET: error %d\n", ret);
+        return ret;
+    }
+
+    ret = sceNetShowNetstat();
+    if (ret == SCE_NET_ERROR_ENOTINIT) {
+        net_memory = malloc(NET_INIT_SIZE);
+        if (!net_memory) {
+          SDLNet_SetError("Could not allocate %d bytes for libnet buffer.",
+              NET_INIT_SIZE);
+          return SCE_NET_ENOMEM;
+        }
+
+        initparam.memory = net_memory;
+        initparam.size = NET_INIT_SIZE;
+        initparam.flags = 0;
+
+        ret = sceNetInit(&initparam);
+        if (ret) {
+            SDLNet_SetError("sceNetInit(): error %d\n", ret);
+            free(net_memory);
+            return ret;
+        }
+    }
+
+    ret = sceNetCtlInit();
+    if (ret) {
+        SDLNet_SetError("sceNetCtlInit(): error %d\n", ret);
+        // SCE_NET_CTL_ERROR_NOT_TERMINATED just means it's already been inited
+        if (ret != SCE_NET_CTL_ERROR_NOT_TERMINATED)
+            return ret;
+    }
+
+    return 0;
+}
+
+// Call this in SDLNet_Quit() after anything else.
+
+void SDLNet_Vita_QuitNet(void)
+{
+    sceNetCtlTerm();
+    sceNetTerm();
+    if (net_memory) {
+        free(net_memory);
+        net_memory = NULL;
+    }
+    sceSysmoduleUnloadModule(SCE_SYSMODULE_NET);
+}
+
+// Don't have these in our libc.
+
+char *_vita_inet_ntoa(struct in_addr in)
+{
+  static char buf[32];
+  int ip;
+  ip = ntohl(in.s_addr);
+  snprintf(buf, sizeof(buf), "%d.%d.%d.%d",
+      (ip >> 24) & 0xff, (ip >> 16) & 0xff, (ip >> 8) & 0xff, ip & 0xff);
+  return buf;
+}
+
+in_addr_t _vita_inet_addr(const char *cp)
+{
+  int b1, b2, b3, b4;
+  int res;
+  res = sscanf(cp, "%d.%d.%d.%d", &b1, &b2, &b3, &b4);
+  if (res != 4) return (in_addr_t)(-1); // is actually expected behavior
+  return htonl((b1 << 24) | (b2 << 16) | (b3 << 8) | b4);
+}
+
+struct hostent *_vita_gethostbyaddr(const void *addr, socklen_t len, int type)
+{
+  static struct hostent ent;
+  static char sname[256];
+  static struct SceNetInAddr saddr;
+  static char *addrlist[2];
+  int rid, e;
+
+  addrlist[0] = (char *)&saddr;
+  addrlist[1] = NULL;
+
+  if (type != AF_INET || len != sizeof(uint32_t)) return NULL;
+
+  rid = sceNetResolverCreate("sdlnet_resolv", NULL, 0);
+  if (rid < 0) return NULL;
+
+  memcpy(&saddr.s_addr, addr, sizeof(uint32_t));
+
+  e = sceNetResolverStartAton(rid, &saddr, sname, sizeof(sname), 0, 0, 0);
+  sceNetResolverDestroy(rid);
+  if (e < 0) return NULL;
+
+  ent.h_name = sname;
+  ent.h_aliases = 0;
+  ent.h_addrtype = AF_INET;
+  ent.h_length = sizeof(struct SceNetInAddr);
+  ent.h_addr_list = addrlist;
+  ent.h_addr = addrlist[0];
+
+  return &ent;
+}
+
+#endif

--- a/SDLnetvita.h
+++ b/SDLnetvita.h
@@ -33,6 +33,7 @@ void SDLNet_Vita_QuitNet(void);
 
 // These are missing from our newlib, so replacements are provided in
 // SDLnetvita.c.
+// REMOVE these after corresponding functions get added to Vita newlib.
 
 char *_vita_inet_ntoa(struct in_addr in);
 in_addr_t _vita_inet_addr(const char *cp);
@@ -53,7 +54,7 @@ struct hostent *_vita_gethostbyaddr(const void *addr, socklen_t len, int type);
 #define random rand
 #define srandom srand
 
-// Some potentially missing constants
+// Some potentially missing constants.
 
 #ifndef SOL_SOCKET
 #define SOL_SOCKET SCE_NET_SOL_SOCKET
@@ -72,4 +73,8 @@ struct hostent *_vita_gethostbyaddr(const void *addr, socklen_t len, int type);
 #undef ip_mreq
 #define ip_mreq SceNetIpMreq
 #define IP_ADD_MEMBERSHIP SCE_NET_IP_ADD_MEMBERSHIP
+#endif
+
+#ifndef TCP_NODELAY
+#define TCP_NODELAY SCE_NET_TCP_NODELAY
 #endif

--- a/SDLnetvita.h
+++ b/SDLnetvita.h
@@ -1,0 +1,75 @@
+/*
+  SDL_net:  An example cross-platform network library for use with SDL
+  Copyright (C) 1997-2017 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+/* $Id$ */
+
+#pragma once
+
+#include <sys/select.h>
+#include <vitasdk.h>
+
+// These are all defined in SDLnetvita.c
+
+int SDLNet_Vita_InitNet(void);
+void SDLNet_Vita_QuitNet(void);
+
+// These are missing from our newlib, so replacements are provided in
+// SDLnetvita.c.
+
+char *_vita_inet_ntoa(struct in_addr in);
+in_addr_t _vita_inet_addr(const char *cp);
+struct hostent *_vita_gethostbyaddr(const void *addr, socklen_t len, int type);
+
+#undef inet_ntoa
+#undef inet_addr
+#undef gethostbyaddr
+#define inet_ntoa _vita_inet_ntoa
+#define inet_addr _vita_inet_addr
+#define gethostbyaddr _vita_gethostbyaddr
+
+// SDL2_net looks for these and uses them exactly as rand() and srand()
+// for some reason, and we don't have them in libc.
+
+#undef random
+#undef srandom
+#define random rand
+#define srandom srand
+
+// Some potentially missing constants
+
+#ifndef SOL_SOCKET
+#define SOL_SOCKET SCE_NET_SOL_SOCKET
+#endif
+
+#ifndef IPPROTO_IP
+#define IPPROTO_IP SCE_NET_IPPROTO_IP
+#endif
+
+#ifndef SO_BROADCAST
+#define SO_BROADCAST SCE_NET_SO_BROADCAST
+#endif
+
+#ifndef IP_ADD_MEMBERSHIP
+// HACK
+#undef ip_mreq
+#define ip_mreq SceNetIpMreq
+#define IP_ADD_MEMBERSHIP SCE_NET_IP_ADD_MEMBERSHIP
+#endif


### PR DESCRIPTION
- add libnet (SCE_SYSMODULE_NET/sceNet*) init and deinit code;
- add replacements for missing socket functions (`inet_ntoa`, `inet_addr`, `gethostbyaddr`);
- add definitions for missing constants (`TCP_NODELAY`, `IP_ADD_MEMBERSHIP`, ...) and `random()`;
- remove unnecessary object from Makefile.vita;
- fix `select()`-related compiler warning.

These changes should make it possible to correctly link and use the library in Vita homebrew applications with no additional hacks. I successfully tested this in Chocolate Doom, should work for other future ports as well.